### PR TITLE
Ensure callback is always called.

### DIFF
--- a/tasks/sitespeed.js
+++ b/tasks/sitespeed.js
@@ -59,7 +59,9 @@ var gulpSitespeedio = function(options) {
 
                 if( isFailing ) {
                     cb(new gutil.PluginError(PLUGIN_NAME, 'FAILED BUDGETS'));   
-                }
+                } else {
+					cb();
+				}
 
 			} else {
                 cb();


### PR DESCRIPTION
I added an extra else statement in the task to ensure that the callback is always called, even when the budget isn't failing. This was useful for me in the following use case:
Start localhost server
Test performance budget with gulp-sitespeedio
Stop the server, regardless of budget failing or passing
