### PR TITLE
Add CLI option to the gulp build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ gulp.task('default', function (done) {
 With this in place, gulp-sitespeedio will now collect performance metrics for your site.
 
 ## The result files
-The result files will automatically be stored in a temporary directory. If you want to change that, use 
+The result files will automatically be stored in a temporary directory. If you want to change that, use
 the *resultBaseDir* property, like this:
 
 ```javascript
@@ -77,7 +77,7 @@ Fetch timings, sending performance metrics to Graphite and performance budgets.
 
 You can choose to collect Navigation Timing and User Timing metrics using real browser. You can choose by using Firefox or Chrome. And you can configure the connection speed ([more info](http://www.sitespeed.io/documentation/#connectionspeed) by choosing between mobile3g, mobile3gfast, cable and native. And choose how many times you want to test each URL (default is 3).
 
-You surely want to combine it with running [Xvfb](https://gist.github.com/nwinkler/f0928740e7ae0e7477dd) to avoid opening the browser. 
+You surely want to combine it with running [Xvfb](https://gist.github.com/nwinkler/f0928740e7ae0e7477dd) to avoid opening the browser.
 
 ```javascript
 {
@@ -166,3 +166,7 @@ Doing the same with the gulp plugin:
     }
 }
 ```
+
+### CLI options
+
+You can use `--txtPath` to pass the txt filename and pass the urls instead adding in the gulp process. By default the file it's inside tasks/data/urls.txt but you can as many txts file you want.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
     "temporary": "0.0.8"
   },
   "devDependencies": {
-    "gulp": "~3.8.11"
+    "gulp": "~3.8.11",
+    "yargs": "^6.4.0",
+    "through2": "^2.0.3",
+    "run-sequence": "^1.2.2",
+    "stream-end": "^0.1.0"
   },
   "main": "./tasks/sitespeed.js",
   "scripts": {

--- a/tasks/data/urls.txt
+++ b/tasks/data/urls.txt
@@ -1,0 +1,2 @@
+https://www.sitespeed.io
+https://www.sitespeed.io/faq/

--- a/tasks/getUrl.js
+++ b/tasks/getUrl.js
@@ -1,0 +1,50 @@
+var fs = require('fs'),
+    argv = require('yargs').argv,
+    through = require('through2'),
+    gutil = require('gulp-util'),
+    PluginError = gutil.PluginError,
+    path = require('path');
+
+module.exports = function() {
+  function readLines(file, encoding, callback) {
+    var remaining = '',
+    array = [];
+
+    if (file.isNull()) {
+      this.push(file);
+      return callback();
+    }
+
+    var urlFile = file.path;
+
+    var input = fs.createReadStream(urlFile);
+
+    function func(data) {
+      return array.push(data);
+    }
+
+    input.on('data', function(data) {
+      remaining += data;
+      var index = remaining.indexOf('\n');
+      var last  = 0;
+      while (index > -1) {
+        var line = remaining.substring(last, index);
+        last = index + 1;
+        func(line);
+        index = remaining.indexOf('\n', last);
+      }
+
+      remaining = remaining.substring(last);
+    });
+
+    input.on('end', function() {
+      if (remaining.length > 0) {
+        func(remaining);
+      } else {
+        return callback(null, array);
+      }
+    });
+  }
+
+  return through.obj(readLines);
+};


### PR DESCRIPTION
We use the file urls.txt to pass the list of urls to analyse, instead going to the gulp task and adding it.